### PR TITLE
Use tableau api

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -43,7 +43,7 @@
 
 .nav-pills .nav-link  {
   background-color: #F1F2F2;
-  text: black;
+  color: black;
   border-radius: 15px;
   height: 25px;
   line-height: 10px;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,4 +1,4 @@
-.graph {
+.graph, .viz-widget {
   border: 1px solid #000000;
   box-sizing: border-box;
   border-radius: 4px;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,7 +1,8 @@
-.graph, .viz-widget {
+ .viz-widget {
   border: 1px solid #000000;
   box-sizing: border-box;
   border-radius: 4px;
+  margin: 15px;
 }
 
 .coa-box-shadow {
@@ -25,3 +26,36 @@
 .coa-resources {
   background-color: #b3d2e0;
 }
+
+.nav-pills .nav-link.active, .nav-pills {
+  border-radius: 15px;
+  height: 25px;
+  line-height: 10px;
+  font-size: 14px;
+  text-align: center;
+
+
+} 
+
+.nav-pills .nav-link.active, .nav-pills .show>.nav-link {
+  background-color: black;
+}
+
+.nav-pills .nav-link  {
+  background-color: #F1F2F2;
+  text: black;
+  border-radius: 15px;
+  height: 25px;
+  line-height: 10px;
+  font-size: 14px;
+  text-align: center;
+  margin: 3px;
+  
+}
+
+body {
+  background-color: #FAF9F9;
+}
+
+
+

--- a/assets/vizList.js
+++ b/assets/vizList.js
@@ -80,3 +80,4 @@ const vizList = [
       "url": "https://public.tableau.com/views/Comparisonofthedemographicsofpeoplewhoexittohousingandreturntohomelessness/Total-Returns?:language=en&:display_count=y&:origin=viz_share_link"
     }
    ];
+   

--- a/assets/vizList.js
+++ b/assets/vizList.js
@@ -1,0 +1,82 @@
+const vizList = [
+    {
+      "section": 1,
+      "section_title": "Newly Homeless",
+      "layer": 1,
+      "visualization_description": "Change in the number of people who are newly homeless",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/Changeinthenumberofpeoplewhoarenewlyhomeless/Sheet1?publish=yes",
+      "url": "https://public.tableau.com/views/Changeinthenumberofpeoplewhoarenewlyhomeless/Sheet1?:language=en&:display_count=y&publish=yes&:origin=viz_share_link"
+    },
+    {
+      "section": 1,
+      "section_title": "Newly Homeless",
+      "layer": 2,
+      "visualization_description": "Break down of the demographics of people who are newly homeless",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/Breakdownofthedemographicsofpeoplewhoarenewlyhomeless/Sheet2?publish=yes",
+      "url": "https://public.tableau.com/views/Breakdownofthedemographicsofpeoplewhoarenewlyhomeless/Sheet2?:language=en&:display_count=y&publish=yes&:origin=viz_share_link"
+    },
+    {
+      "section": 2,
+      "section_title": "Shelter",
+      "layer": 1,
+      "visualization_description": "Change in the total number of beds for shelter",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/Changeinthetotalnumberofbedsusedtoshelterpeople/HousingandShelter2",
+      "url": "https://public.tableau.com/views/Changeinthetotalnumberofbedsusedtoshelterpeople/HousingandShelter2?:language=en&:display_count=y&:origin=viz_share_link"
+    },
+    {
+      "section": 2,
+      "section_title": "Shelter",
+      "layer": 2,
+      "visualization_description": "Change in the total number of people who receive shelter",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/Changeinthetotalnumberofpeoplewhoreceiveshelter/Sheet1?publish=yes",
+      "url": "https://public.tableau.com/views/Changeinthetotalnumberofpeoplewhoreceiveshelter/Sheet1?:language=en&:display_count=y&publish=yes&:origin=viz_share_link"
+    },
+    {
+      "section": 2,
+      "section_title": "Shelter",
+      "layer": 3,
+      "visualization_description": "Comparison of the demographics of people in shelter and people who live in Travis County ",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/ComparisonofthedemographicsofpeopleinshelterandpeoplewholiveinTravisCounty/Total-Shelter?publish=yes",
+      "url": "https://public.tableau.com/views/ComparisonofthedemographicsofpeopleinshelterandpeoplewholiveinTravisCounty/Total-Shelter?:language=en&:display_count=y&publish=yes&:origin=viz_share_link"
+    },
+    {
+      "section": 3,
+      "section_title": "Housing",
+      "layer": 1,
+      "visualization_description": "Change in the total number of beds for housing",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/Changeinthetotalnumberofbedsusedtohousepeople/HousingandShelter3?publish=yes",
+      "url": "https://public.tableau.com/views/Changeinthetotalnumberofbedsusedtohousepeople/HousingandShelter3?:language=en&:display_count=y&publish=yes&:origin=viz_share_link"
+    },
+    {
+      "section": 3,
+      "section_title": "Housing",
+      "layer": 2,
+      "visualization_description": "Change in the total number of people who exit to homelessness to housing",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/Exits_15930134501040/Exits?publish=yes",
+      "url": "https://public.tableau.com/views/Exits_15930134501040/Exits?:language=en&:display_count=y&publish=yes&:origin=viz_share_link"
+    },
+    {
+      "section": 3,
+      "section_title": "Housing",
+      "layer": 3,
+      "visualization_description": "Comparison of the demographics of people who are sheltered and exit to housing",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/Comparisonofthedemographicsofpeoplewhoareshelteredandexittohousing/Total-Housed?publish=yes",
+      "url": "https://public.tableau.com/views/Comparisonofthedemographicsofpeoplewhoareshelteredandexittohousing/Total-Housed?:language=en&:display_count=y&publish=yes&:origin=viz_share_link"
+    },
+    {
+      "section": 4,
+      "section_title": "Returns to Homelessness",
+      "layer": 1,
+      "visualization_description": "Change in the total number of people who return to homelessness",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/ReturnstoHomelessness_15919382098890/Returns-total?publish=yes",
+      "url": "https://public.tableau.com/views/ReturnstoHomelessness_15919382098890/Returns-total?:language=en&:display_count=y&publish=yes&:origin=viz_share_link"
+    },
+    {
+      "section": 4,
+      "section_title": "Returns to Homelessness",
+      "layer": 2,
+      "visualization_description": "Comparison of the demographics of people who exit to housing and return to homelessness",
+      "link": "https://public.tableau.com/profile/sarah.rodriguez#!/vizhome/Comparisonofthedemographicsofpeoplewhoexittohousingandreturntohomelessness/Total-Returns",
+      "url": "https://public.tableau.com/views/Comparisonofthedemographicsofpeoplewhoexittohousingandreturntohomelessness/Total-Returns?:language=en&:display_count=y&:origin=viz_share_link"
+    }
+   ];

--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@
               ></div>
               <div
                 class="tab-pane fade"
-                id="section-2-layer-2"
+                id="section-3-layer-2"
                 role="tabpanel"
                 aria-labelledby="section-3-layer-2-tab"
               ></div>

--- a/index.html
+++ b/index.html
@@ -11,27 +11,11 @@
       type="text/javascript"
       src="https://public.tableau.com/javascripts/api/tableau-2.min.js"
     ></script>
-    <script
-    type="text/javascript"
-    src="assets/vizList.js"
-  ></script>
+    <script type="text/javascript" src="assets/vizList.js"></script>
 
     <script>
       function initializeViz() {
-        // gets lists of urls that we want on the page and their associated html ids
-
-        // key = section
-
-        // `section-${key}-layer-${value}`
-
-        vizUrls = {
-          "section-1-layer-1":
-            "https://public.tableau.com/views/Changeinthenumberofpeoplewhoarenewlyhomeless/Sheet1?:language=en&:display_count=y&publish=yes&:origin=viz_share_link",
-          "section-1-layer-2":
-            "https://public.tableau.com/views/Breakdownofthedemographicsofpeoplewhoarenewlyhomeless/Sheet2?:language=en&:display_count=y&publish=yes&:origin=viz_share_link",
-        };
-        vizIds = ["section-1-layer-1", "section-1-layer-2"];
-
+        // gets lists of urls that we want on the page and their associated html ids from vizList
         // An object that contains options specifying how to embed the viz
         var options = {
           height: "350px",
@@ -39,12 +23,11 @@
         };
 
         for (const [key, viz] of Object.entries(vizList)) {
-          console.log(`${key}: ${viz}`);
+          // console.log(`${key}: ${viz}`);
           let divId = `section-${viz.section}-layer-${viz.layer}`;
           let url = viz.url;
           let vizDiv = document.getElementById(divId);
           let = new tableau.Viz(vizDiv, url, options);
-
         }
       }
     </script>
@@ -369,6 +352,7 @@
     <div>
       <div class="container">
         <div class="row">
+          <!-- Newly Homeless -->
           <div class="col-md-6 viz-widget">
             <h2>Newly Homeless</h2>
             <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
@@ -409,81 +393,182 @@
                 id="section-1-layer-2"
                 role="tabpanel"
                 aria-labelledby="section-1-layer-2-tab"
-              >
-              </div>
-
+              ></div>
             </div>
           </div>
-          
-            <div class="col-md-6 viz-widget">
-              <h2>Shelter</h2>
-              <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
-                <li class="nav-item">
-                  <a
-                    class="nav-link active"
-                    id="section-2-layer-1-tab"
-                    data-toggle="pill"
-                    href="#section-2-layer-1"
-                    role="tab"
-                    aria-controls="section-2-layer-1"
-                    aria-selected="true"
-                    >Beds</a
-                  >
-                </li>
-                <li class="nav-item">
-                  <a
-                    class="nav-link"
-                    id="section-2-layer-2-tab"
-                    data-toggle="pill"
-                    href="#section-2-layer-2"
-                    role="tab"
-                    aria-controls="section-2-layer-2"
-                    aria-selected="false"
-                    >Individuals</a
-                  >
-                </li>
-                <li class="nav-item">
-                  <a
-                    class="nav-link"
-                    id="section-2-layer-3-tab"
-                    data-toggle="pill"
-                    href="#section-2-layer-3"
-                    role="tab"
-                    aria-controls="section-2-layer-3"
-                    aria-selected="false"
-                    >Demographics</a
-                  >
-                </li>
-              </ul>
-              <div class="tab-content" id="pills-tabContent">
-                <div
-                  class="tab-pane fade show active"
-                  id="section-2-layer-1"
-                  role="tabpanel"
-                  aria-labelledby="section-2-layer-1-tab"
-                ></div>
-                <div
-                  class="tab-pane fade"
-                  id="section-2-layer-2"
-                  role="tabpanel"
-                  aria-labelledby="section-2-layer-2-tab"
-                ></div>
-                <div
+          <!-- Shelter -->
+          <div class="col-md-6 viz-widget">
+            <h2>Shelter</h2>
+            <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
+              <li class="nav-item">
+                <a
+                  class="nav-link active"
+                  id="section-2-layer-1-tab"
+                  data-toggle="pill"
+                  href="#section-2-layer-1"
+                  role="tab"
+                  aria-controls="section-2-layer-1"
+                  aria-selected="true"
+                  >Beds</a
+                >
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  id="section-2-layer-2-tab"
+                  data-toggle="pill"
+                  href="#section-2-layer-2"
+                  role="tab"
+                  aria-controls="section-2-layer-2"
+                  aria-selected="false"
+                  >Individuals</a
+                >
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  id="section-2-layer-3-tab"
+                  data-toggle="pill"
+                  href="#section-2-layer-3"
+                  role="tab"
+                  aria-controls="section-2-layer-3"
+                  aria-selected="false"
+                  >Demographics</a
+                >
+              </li>
+            </ul>
+            <div class="tab-content" id="pills-tabContent">
+              <div
+                class="tab-pane fade show active"
+                id="section-2-layer-1"
+                role="tabpanel"
+                aria-labelledby="section-2-layer-1-tab"
+              ></div>
+              <div
+                class="tab-pane fade"
+                id="section-2-layer-2"
+                role="tabpanel"
+                aria-labelledby="section-2-layer-2-tab"
+              ></div>
+              <div
                 class="tab-pane fade"
                 id="section-2-layer-3"
                 role="tabpanel"
                 aria-labelledby="section-2-layer-3-tab"
-              >
-                </div>
-  
-              </div>
+              ></div>
+            </div>
+          </div>
+          <!-- Housing -->
+          <div class="col-md-6 viz-widget">
+            <h2>Housing</h2>
+            <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
+              <li class="nav-item">
+                <a
+                  class="nav-link active"
+                  id="section-3-layer-1-tab"
+                  data-toggle="pill"
+                  href="#section-3-layer-1"
+                  role="tab"
+                  aria-controls="section-3-layer-1"
+                  aria-selected="true"
+                  >Beds</a
+                >
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  id="section-3-layer-2-tab"
+                  data-toggle="pill"
+                  href="#section-3-layer-2"
+                  role="tab"
+                  aria-controls="section-3-layer-2"
+                  aria-selected="false"
+                  >Individuals</a
+                >
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  id="section-3-layer-3-tab"
+                  data-toggle="pill"
+                  href="#section-3-layer-3"
+                  role="tab"
+                  aria-controls="section-3-layer-3"
+                  aria-selected="false"
+                  >Demographics</a
+                >
+              </li>
+            </ul>
+            <div class="tab-content" id="pills-tabContent">
+              <div
+                class="tab-pane fade show active"
+                id="section-3-layer-1"
+                role="tabpanel"
+                aria-labelledby="section-3-layer-1-tab"
+              ></div>
+              <div
+                class="tab-pane fade"
+                id="section-2-layer-2"
+                role="tabpanel"
+                aria-labelledby="section-3-layer-2-tab"
+              ></div>
+              <div
+                class="tab-pane fade"
+                id="section-3-layer-3"
+                role="tabpanel"
+                aria-labelledby="section-3-layer-3-tab"
+              ></div>
+            </div>
+          </div>
+          <!-- Returns to Homeless -->
+          <div class="col-md-6 viz-widget">
+            <h2>Returns to Homeless</h2>
+            <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
+              <li class="nav-item">
+                <a
+                  class="nav-link active"
+                  id="section-4-layer-1-tab"
+                  data-toggle="pill"
+                  href="#section-4-layer-1"
+                  role="tab"
+                  aria-controls="section-4-layer-1"
+                  aria-selected="true"
+                  >Individuals</a
+                >
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  id="section-4-layer-2-tab"
+                  data-toggle="pill"
+                  href="#section-4-layer-2"
+                  role="tab"
+                  aria-controls="section-4-layer-2"
+                  aria-selected="false"
+                  >Demographics</a
+                >
+              </li>
+            </ul>
+            <div class="tab-content" id="pills-tabContent">
+              <div
+                class="tab-pane fade show active"
+                id="section-4-layer-1"
+                role="tabpanel"
+                aria-labelledby="section-4-layer-1-tab"
+              ></div>
+              <div
+                class="tab-pane fade"
+                id="section-4-layer-2"
+                role="tabpanel"
+                aria-labelledby="section-4-layer-2-tab"
+              ></div>
             </div>
           </div>
         </div>
       </div>
     </div>
 
-    <div>
+    <!-- <div>
       <div class="container">
         <div class="row">
           <div class="col-md-6">
@@ -504,7 +589,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </div> -->
     <footer class="container py-5">
       <div class="row">
         <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -353,7 +353,7 @@
       <div class="container">
         <div class="row">
           <!-- Newly Homeless -->
-          <div class="col-md-6 viz-widget">
+          <div class="col viz-widget card">
             <h2>Newly Homeless</h2>
             <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
               <li class="nav-item">
@@ -397,7 +397,7 @@
             </div>
           </div>
           <!-- Shelter -->
-          <div class="col-md-6 viz-widget">
+          <div class="col viz-widget card">
             <h2>Shelter</h2>
             <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
               <li class="nav-item">
@@ -458,8 +458,10 @@
               ></div>
             </div>
           </div>
+        </div>
+        <div class="row">
           <!-- Housing -->
-          <div class="col-md-6 viz-widget">
+          <div class="col viz-widget card">
             <h2>Housing</h2>
             <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
               <li class="nav-item">
@@ -521,7 +523,7 @@
             </div>
           </div>
           <!-- Returns to Homeless -->
-          <div class="col-md-6 viz-widget">
+          <div class="col viz-widget card">
             <h2>Returns to Homeless</h2>
             <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
               <li class="nav-item">

--- a/index.html
+++ b/index.html
@@ -11,16 +11,26 @@
       type="text/javascript"
       src="https://public.tableau.com/javascripts/api/tableau-2.min.js"
     ></script>
+    <script
+    type="text/javascript"
+    src="assets/vizList.js"
+  ></script>
+
     <script>
       function initializeViz() {
         // gets lists of urls that we want on the page and their associated html ids
+
+        // key = section
+
+        // `section-${key}-layer-${value}`
+
         vizUrls = {
-          "row-one-viz-one":
+          "section-1-layer-1":
             "https://public.tableau.com/views/Changeinthenumberofpeoplewhoarenewlyhomeless/Sheet1?:language=en&:display_count=y&publish=yes&:origin=viz_share_link",
-          "row-one-viz-two":
+          "section-1-layer-2":
             "https://public.tableau.com/views/Breakdownofthedemographicsofpeoplewhoarenewlyhomeless/Sheet2?:language=en&:display_count=y&publish=yes&:origin=viz_share_link",
         };
-        vizIds = ["row-one-viz-one", "row-one-viz-two"];
+        vizIds = ["section-1-layer-1", "section-1-layer-2"];
 
         // An object that contains options specifying how to embed the viz
         var options = {
@@ -28,11 +38,13 @@
           width: "100%",
         };
 
-        for (const [key, value] of Object.entries(vizUrls)) {
-          // console.log(`${key}: ${value}`);
-          var placeholderDiv = document.getElementById(key);
-          var url = value;
-          viz = new tableau.Viz(placeholderDiv, url, options);
+        for (const [key, viz] of Object.entries(vizList)) {
+          console.log(`${key}: ${viz}`);
+          let divId = `section-${viz.section}-layer-${viz.layer}`;
+          let url = viz.url;
+          let vizDiv = document.getElementById(divId);
+          let = new tableau.Viz(vizDiv, url, options);
+
         }
       }
     </script>
@@ -356,18 +368,18 @@
     </div>
     <div>
       <div class="container">
-        <div class="row graphs">
+        <div class="row">
           <div class="col-md-6 viz-widget">
             <h2>Newly Homeless</h2>
             <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
               <li class="nav-item">
                 <a
                   class="nav-link active"
-                  id="row-one-viz-one-tab"
+                  id="section-1-layer-1-tab"
                   data-toggle="pill"
-                  href="#row-one-viz-one"
+                  href="#section-1-layer-1"
                   role="tab"
-                  aria-controls="row-one-viz-one"
+                  aria-controls="section-1-layer-1"
                   aria-selected="true"
                   >Individuals</a
                 >
@@ -375,11 +387,11 @@
               <li class="nav-item">
                 <a
                   class="nav-link"
-                  id="row-one-viz-two-tab"
+                  id="section-1-layer-2-tab"
                   data-toggle="pill"
-                  href="#row-one-viz-two"
+                  href="#section-1-layer-2"
                   role="tab"
-                  aria-controls="row-one-viz-two"
+                  aria-controls="section-1-layer-2"
                   aria-selected="false"
                   >Demographics</a
                 >
@@ -388,29 +400,83 @@
             <div class="tab-content" id="pills-tabContent">
               <div
                 class="tab-pane fade show active"
-                id="row-one-viz-one"
+                id="section-1-layer-1"
                 role="tabpanel"
-                aria-labelledby="row-one-viz-one-tab"
+                aria-labelledby="section-1-layer-1-tab"
               ></div>
               <div
                 class="tab-pane fade"
-                id="row-one-viz-two"
+                id="section-1-layer-2"
                 role="tabpanel"
-                aria-labelledby="row-one-viz-two-tab"
+                aria-labelledby="section-1-layer-2-tab"
               >
               </div>
 
             </div>
           </div>
-          <div class="col-md-6">
-            <div
-              class="embed-responsive embed-responsive-16by9 graph"
-              style="margin-bottom: 30px; margin-top: 40px;"
-            >
-              <iframe
-                class="embed-responsive-item"
-                src="   https://public.tableau.com/views/PeopleShelterbyYear/Overtime?:language=en&:display_count=y&:origin=viz_share_link:showVizHome=no&:embed=true"
-              ></iframe>
+          
+            <div class="col-md-6 viz-widget">
+              <h2>Shelter</h2>
+              <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
+                <li class="nav-item">
+                  <a
+                    class="nav-link active"
+                    id="section-2-layer-1-tab"
+                    data-toggle="pill"
+                    href="#section-2-layer-1"
+                    role="tab"
+                    aria-controls="section-2-layer-1"
+                    aria-selected="true"
+                    >Beds</a
+                  >
+                </li>
+                <li class="nav-item">
+                  <a
+                    class="nav-link"
+                    id="section-2-layer-2-tab"
+                    data-toggle="pill"
+                    href="#section-2-layer-2"
+                    role="tab"
+                    aria-controls="section-2-layer-2"
+                    aria-selected="false"
+                    >Individuals</a
+                  >
+                </li>
+                <li class="nav-item">
+                  <a
+                    class="nav-link"
+                    id="section-2-layer-3-tab"
+                    data-toggle="pill"
+                    href="#section-2-layer-3"
+                    role="tab"
+                    aria-controls="section-2-layer-3"
+                    aria-selected="false"
+                    >Demographics</a
+                  >
+                </li>
+              </ul>
+              <div class="tab-content" id="pills-tabContent">
+                <div
+                  class="tab-pane fade show active"
+                  id="section-2-layer-1"
+                  role="tabpanel"
+                  aria-labelledby="section-2-layer-1-tab"
+                ></div>
+                <div
+                  class="tab-pane fade"
+                  id="section-2-layer-2"
+                  role="tabpanel"
+                  aria-labelledby="section-2-layer-2-tab"
+                ></div>
+                <div
+                class="tab-pane fade"
+                id="section-2-layer-3"
+                role="tabpanel"
+                aria-labelledby="section-2-layer-3-tab"
+              >
+                </div>
+  
+              </div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -567,29 +567,6 @@
         </div>
       </div>
     </div>
-
-    <!-- <div>
-      <div class="container">
-        <div class="row">
-          <div class="col-md-6">
-            <div class="embed-responsive embed-responsive-16by9 graph">
-              <iframe
-                class="embed-responsive-item"
-                src="https://public.tableau.com/views/Exits_15930134501040/Exits?:language=en&:display_count=y&:origin=viz_share_link:showVizHome=no&:embed=true"
-              ></iframe>
-            </div>
-          </div>
-          <div class="col-md-6">
-            <div class="embed-responsive embed-responsive-16by9 graph">
-              <iframe
-                class="embed-responsive-item"
-                src="https://public.tableau.com/views/Fundingovertime/Funding-year?:language=en&:display_count=y&:origin=viz_share_link:showVizHome=no&:embed=true"
-              ></iframe>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div> -->
     <footer class="container py-5">
       <div class="row">
         <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -7,6 +7,35 @@
       content="width=device-width, initial-scale=1.0, shrink-to-fit=no"
     />
     <title>dashboard1</title>
+    <script
+      type="text/javascript"
+      src="https://public.tableau.com/javascripts/api/tableau-2.min.js"
+    ></script>
+    <script>
+      function initializeViz() {
+        // gets lists of urls that we want on the page and their associated html ids
+        vizUrls = {
+          "row-one-viz-one":
+            "https://public.tableau.com/views/Changeinthenumberofpeoplewhoarenewlyhomeless/Sheet1?:language=en&:display_count=y&publish=yes&:origin=viz_share_link",
+          "row-one-viz-two":
+            "https://public.tableau.com/views/Breakdownofthedemographicsofpeoplewhoarenewlyhomeless/Sheet2?:language=en&:display_count=y&publish=yes&:origin=viz_share_link",
+        };
+        vizIds = ["row-one-viz-one", "row-one-viz-two"];
+
+        // An object that contains options specifying how to embed the viz
+        var options = {
+          height: "350px",
+          width: "100%",
+        };
+
+        for (const [key, value] of Object.entries(vizUrls)) {
+          // console.log(`${key}: ${value}`);
+          var placeholderDiv = document.getElementById(key);
+          var url = value;
+          viz = new tableau.Viz(placeholderDiv, url, options);
+        }
+      }
+    </script>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap.min.css"
@@ -14,7 +43,7 @@
     <link rel="stylesheet" href="assets/css/styles.css" />
   </head>
 
-  <body>
+  <body onload="initializeViz();">
     <div>
       <nav class="coa-box-shadow">
         <div class="container mt-1">
@@ -328,15 +357,49 @@
     <div>
       <div class="container">
         <div class="row graphs">
-          <div class="col-md-6">
-            <div
-              class="embed-responsive embed-responsive-16by9 graph"
-              style="margin-top: 40px;"
-            >
-              <iframe
-                class="embed-responsive-item"
-                src="https://public.tableau.com/views/TotalBedsbyYear/Sheet1?:language=en&:display_count=y&:origin=viz_share_link:showVizHome=no&:embed=true"
-              ></iframe>
+          <div class="col-md-6 viz-widget">
+            <h2>Newly Homeless</h2>
+            <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
+              <li class="nav-item">
+                <a
+                  class="nav-link active"
+                  id="row-one-viz-one-tab"
+                  data-toggle="pill"
+                  href="#row-one-viz-one"
+                  role="tab"
+                  aria-controls="row-one-viz-one"
+                  aria-selected="true"
+                  >Individuals</a
+                >
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  id="row-one-viz-two-tab"
+                  data-toggle="pill"
+                  href="#row-one-viz-two"
+                  role="tab"
+                  aria-controls="row-one-viz-two"
+                  aria-selected="false"
+                  >Demographics</a
+                >
+              </li>
+            </ul>
+            <div class="tab-content" id="pills-tabContent">
+              <div
+                class="tab-pane fade show active"
+                id="row-one-viz-one"
+                role="tabpanel"
+                aria-labelledby="row-one-viz-one-tab"
+              ></div>
+              <div
+                class="tab-pane fade"
+                id="row-one-viz-two"
+                role="tabpanel"
+                aria-labelledby="row-one-viz-two-tab"
+              >
+              </div>
+
             </div>
           </div>
           <div class="col-md-6">
@@ -404,6 +467,7 @@
         </div>
       </div>
     </footer>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/js/bootstrap.bundle.min.js"></script>
   </body>


### PR DESCRIPTION
This is a big change. 

Instead of embedding iframes, we use the tableau API. 

The api ends up rendering iframes, but at least we control them in a manageable way now.

it reads in a JSON file that matches the structure of this google sheet:
https://docs.google.com/spreadsheets/d/1AhNY1nELONPMdwEhTI0EOPx5BF_94whOyQobtcnPw3s/edit#gid=0

which will make it much easier to update the links in the future, and also lays the groundwork to have other content be not managed in the code directly
it also makes it easier to structure the code for this project in such a way that if/when it gets picked up or re-written as part of alpha or something else there will be more pieces of it that can be reused
this way, too, if we keep having iframe problems we hopefully have more options to mitigate. like if one dosen't load now, i can actually tell which one failed in the code, so we might be able to wrap them in some javascript to retry an iframe if it fails
one downside of the way its currently implemented is the initial pageload takes longer, cause its loading all of the visualizations at once essentially, instead of when you click the tab. but thats an improvement we might be able to make incrementally and IMO isn't a blocker for MVP
also these embeds are a bit more responsive, if the window size changes they will resize the visualization